### PR TITLE
EMF-1323: Update to v1.6.2 - Improve startSession on Android and permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 1.6.2
+- Fixed startSession callback handling on Android.
+- Fixed permission request resolution for Android < 13.
+
 ## 1.6.1
 - Update native sdk dependencies: added new setUserLanguage method that allows users to manually set the language instead of relying on auto-detection.
 - Fix cancelOrder, setCustomerId, handleLink and disableUserTracking.

--- a/android/src/main/kotlin/io/emma/emma_flutter_sdk/EmmaFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/emma/emma_flutter_sdk/EmmaFlutterSdkPlugin.kt
@@ -12,6 +12,7 @@ import io.emma.android.interfaces.EMMABatchNativeAdInterface
 import io.emma.android.interfaces.EMMAInAppMessageInterface
 import io.emma.android.interfaces.EMMANativeAdInterface
 import io.emma.android.interfaces.EMMAPermissionInterface
+import io.emma.android.interfaces.EMMASessionStartListener
 import io.emma.android.utils.EMMALog
 import io.emma.android.utils.EMMAUtils
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -205,8 +206,11 @@ class EmmaFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Pl
 
     val configuration = configurationBuilder.build()
 
-    EMMA.getInstance().startSession(configuration)
-    result.success(null)
+    EMMA.getInstance().startSession(configuration, object : EMMASessionStartListener {
+      override fun onSessionStarted() {
+        result.success(null)
+      }
+    })
   }
 
   private fun trackEvent(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -543,6 +547,7 @@ class EmmaFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Pl
   private fun requestNotificationPermission(@NonNull call: MethodCall, @NonNull result: Result) {
       if (Build.VERSION.SDK_INT < 33 || EMMAUtils.getTargetSdkVersion(applicationContext) < 33) {
         Utils.executeOnMainThread(channel, "Emma#onPermissionStatus", PermissionStatus.Unsupported.ordinal)
+        result.success(null)
         return
       }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,6 +72,7 @@ class _MyAppState extends State<MyApp> {
         print('Notifications permission status: ' + status.toString());
       });
       await EmmaFlutterSdk.shared.requestNotificationsPermission();
+      await EmmaFlutterSdk.shared.checkForRichPush();
     }
 
     return await EmmaFlutterSdk.shared.startPushSystem('icimage');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: emma_flutter_sdk
 description: EMMA SDK implementation for flutter. This package contains native bindings for our official SDK's. You can find more info at https://support.emma.io or https://www.emma.io
-version: 1.6.1
+version: 1.6.2
 homepage: https://www.emma.io
 
 environment:


### PR DESCRIPTION
This PR improves the initialization flow and notification permission handling for the Android side of the Flutter SDK:

* Added usage of `EMMASessionStartListener` in `startSession` to ensure the method returns control to Flutter only after the session is fully started.
* Updated `requestNotificationPermission` to properly call `result.success(null)` when the device is running Android < 33.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the startSession callback on Android to ensure proper session start confirmation.
  * Corrected notification permission request resolution for Android versions below 13.

* **Chores**
  * Updated changelog and version number to 1.6.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->