### PR TITLE
EMF-1375: update iOS SDK dependency and Android notificationChannelId handling on startPushSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 1.6.3
+- Update the native iOS SDK dependency: iOS 26 update.
+- Fix notificationChannelId only being set when it is not null on Android.
+
 ## 1.6.2
 - Fixed startSession callback handling on Android.
 - Fixed permission request resolution for Android < 13.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 1.6.3
-- Update the native iOS SDK dependency: iOS 26 update.
+- Update iOS SDK dependency to version 4.15.5.
 - Fix notificationChannelId only being set when it is not null on Android.
 
 ## 1.6.2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'io.emma.emma_flutter_sdk'
-version '1.6.2'
+version '1.6.3'
 
 buildscript {
     ext.kotlin_version = '1.6.0'

--- a/android/src/main/kotlin/io/emma/emma_flutter_sdk/EmmaFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/emma/emma_flutter_sdk/EmmaFlutterSdkPlugin.kt
@@ -334,7 +334,7 @@ class EmmaFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Pl
     val defaultChannel  = Utils.getAppName(applicationContext) ?: "EMMA"
 
     val channelName = call.argument<String>("notificationChannel") ?: defaultChannel
-    val notificationChannelId = call.argument<String>("notificationChannelId")
+    val notificationChannelId = call.argument<String>("notificationChannelId")?.trim()
 
     if (pushIcon == 0) {
       return returnError(result, call.method, "pushIcon")
@@ -343,7 +343,7 @@ class EmmaFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Pl
     val pushOpt = EMMAPushOptions.Builder(activity::class.java, pushIcon)
             .setNotificationChannelName(channelName)
 
-    if (notificationChannelId != null) {
+    if (!notificationChannelId.isNullOrBlank()) {
       pushOpt.setNotificationChannelId(notificationChannelId)
     }
 

--- a/android/src/main/kotlin/io/emma/emma_flutter_sdk/EmmaFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/emma/emma_flutter_sdk/EmmaFlutterSdkPlugin.kt
@@ -343,7 +343,7 @@ class EmmaFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Pl
     val pushOpt = EMMAPushOptions.Builder(activity::class.java, pushIcon)
             .setNotificationChannelName(channelName)
 
-    if (notificationChannelId == null) {
+    if (notificationChannelId != null) {
       pushOpt.setNotificationChannelId(notificationChannelId)
     }
 

--- a/ios/emma_flutter_sdk.podspec
+++ b/ios/emma_flutter_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'emma_flutter_sdk'
-  s.version          = '1.6.2'
+  s.version          = '1.6.3'
   s.summary          = 'EMMA SDK implementation for flutter'
   s.description      = <<-DESC
   EMMA SDK implementation for flutter
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   # dependencies
-  s.dependency 'eMMa', '~> 4.15.4'
+  s.dependency 'eMMa', '~> 4.15.5'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: emma_flutter_sdk
 description: EMMA SDK implementation for flutter. This package contains native bindings for our official SDK's. You can find more info at https://support.emma.io or https://www.emma.io
-version: 1.6.2
+version: 1.6.3
 homepage: https://www.emma.io
 
 environment:


### PR DESCRIPTION
This PR introduces the following changes:

- Updates the native iOS SDK dependency: 4.15.5.
- Fixes an issue where notificationChannelId was always being set, ensuring it is only applied when not null on Android (startPushSystem)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Android: Push notifications now apply the notification channel ID only when a valid non-blank value is provided, preventing unintended null/blank assignments.

- Chores
  - Bumped package versions to 1.6.3 across platforms.
  - Updated iOS SDK dependency to 4.15.5.

- Documentation
  - Added a 1.6.3 changelog entry summarizing the Android fix and iOS SDK update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->